### PR TITLE
refactor: migrate to shared html utils and add secret validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { fetchWithTimeout } from './shared/fetch-helpers.js';
+import { escapeHtml, sanitizeParam } from './shared/html.js';
 
 // =============================================================================
 // probationary-firefighter-display — Cloudflare Worker
@@ -133,6 +134,26 @@ export default {
     // browser-based testing where the display system background is not present.
     // Production display URLs should never include this parameter.
     const darkBg = url.searchParams.get('bg') === 'dark';
+
+    var REQUIRED_SECRETS = [
+      'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+      'GOOGLE_PRIVATE_KEY',
+      'GOOGLE_SHEET_ID',
+      'GOOGLE_DRIVE_FOLDER_ID'
+    ];
+    for (var i = 0; i < REQUIRED_SECRETS.length; i++) {
+      var key = REQUIRED_SECRETS[i];
+      if (!env[key]) {
+        console.error('[probationary-firefighter-display] Missing required secret: ' + key);
+        return renderErrorPage(
+          'CONFIGURATION ERROR',
+          'Missing secret: ' + key,
+          layout,
+          layoutKey,
+          darkBg
+        );
+      }
+    }
 
     // Compute the rotation block index synchronously before the cache check.
     // The block index is stable for ROTATION_DAYS days at a time and serves
@@ -707,30 +728,6 @@ async function fetchPhotoData(fileId, accessToken) {
     console.error('Photo fetch exception for Drive file ID "' + fileId + '":', err);
     return null;
   }
-}
-
-
-// =============================================================================
-// INPUT HELPERS
-// =============================================================================
-
-// Sanitizes a URL parameter value to prevent injection attacks.
-// Allows only alphanumeric characters, hyphens, and underscores.
-function sanitizeParam(value) {
-  if (!value || typeof value !== 'string') return null;
-  return value.replace(/[^a-zA-Z0-9_-]/g, '').substring(0, 50);
-}
-
-// Escapes a string for safe insertion into HTML content.
-// Applied to all values sourced from the Google Sheet before injection.
-function escapeHtml(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 }
 
 


### PR DESCRIPTION
## Summary

Three changes in `src/index.js`:

1. **Phase 4 — shared HTML utils**: Imports `escapeHtml` and `sanitizeParam` from `src/shared/html.js` and removes the local copies of both functions. Behavior unchanged.

2. **Phase 5 — secret validation**: Adds required-secret validation at the top of the fetch handler, after `layout`/`darkBg` parsing. Missing secrets now produce a clear `CONFIGURATION ERROR` page rather than a cryptic downstream failure. Closes #14.

3. `fetchWithTimeout` import was already present from Phase 3.

## Test plan

- [ ] Deploy to a staging environment and verify the Worker renders normally when all four secrets are present
- [ ] Temporarily remove one secret and verify a `CONFIGURATION ERROR` page appears (not a 500 or cryptic Drive/Sheets error)
- [ ] Verify all layouts (`full`, `wide`, `split`, `tri`) still render correctly
- [ ] Verify `?bg=dark` still applies the dark background

## Closes

- #14 — `[AUDIT] Validate required env secrets before API calls`

https://claude.ai/code/session_01P3qZKDZzNJb2qWGSkZ971H