### PR TITLE
refactor: migrate to shared google-auth and constants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import { fetchWithTimeout } from './shared/fetch-helpers.js';
 import { escapeHtml, sanitizeParam } from './shared/html.js';
+import { getAccessToken } from './shared/google-auth.js';
+import { DARK_BG_COLOR } from './shared/constants.js';
 
 // =============================================================================
 // probationary-firefighter-display — Cloudflare Worker
@@ -86,18 +88,9 @@ const FIXED_COLUMNS = new Set(['name', 'badge', 'hire date', 'shift', 'rank', 'p
 // FFD brand red — used for the title bar (full layout only) and accent divider.
 const ACCENT_COLOR = '#C8102E';
 
-// Dark background color used when ?bg=dark is specified. Approximates the
-// dark charcoal texture of the station display system background, making
-// text and layout easier to evaluate when testing in a browser.
-const DARK_BG_COLOR = '#111111';
-
 // Name of the data tab in the Google Sheet.
 // Update this constant if the tab is ever renamed.
 const SHEET_TAB_NAME = 'Firefighters';
-
-// Google OAuth2 scope for Sheets and Drive API access.
-// drive.readonly covers both APIs with a single token.
-const GOOGLE_AUTH_SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
 
 // How long the error/retry page waits before reloading (seconds).
 const ERROR_RETRY_SECONDS = 60;
@@ -190,7 +183,8 @@ export default {
       // handles all upstream requests.
       const accessToken = await getAccessToken(
         env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
-        env.GOOGLE_PRIVATE_KEY
+        env.GOOGLE_PRIVATE_KEY,
+        'https://www.googleapis.com/auth/drive.readonly'
       );
 
       // Fetch firefighter records and the Drive photo map in parallel.
@@ -423,105 +417,6 @@ function formatHireDate(dateStr) {
     month:    'long',
     day:      'numeric',
   }).format(new Date(dateStr + 'T12:00:00Z'));
-}
-
-
-// =============================================================================
-// GOOGLE SERVICE ACCOUNT AUTHENTICATION
-// =============================================================================
-// Generates a short-lived Google OAuth2 access token from service account
-// credentials stored as Worker secrets. Uses RSA-SHA256 JWT signing via the
-// Web Crypto API built into Cloudflare Workers — no external dependencies.
-// Copied from daily-message-display, which shares the same service account.
-//
-// Required secrets:
-//   GOOGLE_SERVICE_ACCOUNT_EMAIL — service account email address
-//   GOOGLE_PRIVATE_KEY           — RSA private key from Google Cloud JSON key
-
-async function getAccessToken(email, rawPrivateKey) {
-
-  // Step 1 — Build the JWT header and payload.
-  const now     = Math.floor(Date.now() / 1000);
-  const header  = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
-  const payload = base64url(JSON.stringify({
-    iss:   email,
-    scope: GOOGLE_AUTH_SCOPE,
-    aud:   'https://oauth2.googleapis.com/token',
-    iat:   now,
-    exp:   now + 3600,
-  }));
-
-  const signingInput = header + '.' + payload;
-
-  // Step 2 — Import the RSA private key via the Web Crypto API.
-  // The key arrives from the GitHub secret with literal \n sequences;
-  // convert them to real newlines before stripping the PEM envelope.
-  const pemString = rawPrivateKey.replace(/\\n/g, '\n');
-  const pemBody   = pemString
-    .replace('-----BEGIN PRIVATE KEY-----', '')
-    .replace('-----END PRIVATE KEY-----', '')
-    .replace('-----BEGIN RSA PRIVATE KEY-----', '')
-    .replace('-----END RSA PRIVATE KEY-----', '')
-    .replace(/\n/g, '')
-    .trim();
-
-  const binaryKey = Uint8Array.from(atob(pemBody), c => c.charCodeAt(0));
-
-  const cryptoKey = await crypto.subtle.importKey(
-    'pkcs8',
-    binaryKey,
-    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-    false,
-    ['sign']
-  );
-
-  // Step 3 — Sign the JWT.
-  // arrayBufferToBase64url uses a byte-by-byte loop to avoid call-stack
-  // overflow on large buffers like RSA signatures.
-  const signatureBuf = await crypto.subtle.sign(
-    'RSASSA-PKCS1-v1_5',
-    cryptoKey,
-    new TextEncoder().encode(signingInput)
-  );
-
-  const jwt = signingInput + '.' + arrayBufferToBase64url(signatureBuf);
-
-  // Step 4 — Exchange the signed JWT for a short-lived access token.
-  const tokenRes = await fetchWithTimeout('https://oauth2.googleapis.com/token', {
-    method:  'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body:    'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=' + jwt,
-  }, 10000);
-
-  if (!tokenRes.ok) {
-    const errText = await tokenRes.text();
-    throw new Error('Token exchange failed (' + tokenRes.status + '): ' + errText);
-  }
-
-  const tokenData = await tokenRes.json();
-  return tokenData.access_token;
-}
-
-// Encodes a string to base64url format (used in JWT construction).
-function base64url(str) {
-  return btoa(str)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
-}
-
-// Converts an ArrayBuffer to base64url using a safe byte-by-byte loop.
-// The spread operator can throw a RangeError on large buffers — this avoids it.
-function arrayBufferToBase64url(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
 }
 
 


### PR DESCRIPTION
## Summary

- Imports `getAccessToken` from `src/shared/google-auth.js`; removes local copies of `getAccessToken`, `base64url`, and `arrayBufferToBase64url` (~80 lines removed). Scope passed as literal string parameter.
- Imports `DARK_BG_COLOR` from `src/shared/constants.js`; removes local constant definition.
- Removes local `GOOGLE_AUTH_SCOPE` constant — scope is now passed directly to the shared `getAccessToken` function.

Part of Phase 6 shared-utils migration.

## Test plan

- [ ] Verify Worker deploys without errors
- [ ] Confirm probationary firefighter page renders correctly (photo + bio)
- [ ] Confirm `?bg=dark` still applies the dark background
- [ ] Confirm Google auth token exchange succeeds (no 401s from Sheets/Drive APIs)