### PR TITLE
feat: add /healthz endpoint for uptime monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,46 @@ export default {
     // Parse and validate the layout URL parameter before the try block so the
     // error page renderer always has a valid layout to work with.
     const url         = new URL(request.url);
+
+    if (url.pathname === '/healthz') {
+      var healthStatus = 'healthy';
+      var healthDetail = '';
+
+      try {
+        var probeRes = await fetchWithTimeout(
+          'https://oauth2.googleapis.com/token',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'grant_type=placeholder',
+          },
+          5000
+        );
+        if (probeRes.status === 400) {
+          healthDetail = 'google-apis: reachable';
+        } else {
+          healthStatus = 'degraded';
+          healthDetail = 'google-apis: unexpected status ' + probeRes.status;
+        }
+      } catch (e) {
+        healthStatus = 'degraded';
+        healthDetail = 'google-apis: unreachable (' + (e && e.message ? e.message : String(e)) + ')';
+      }
+
+      return new Response(
+        'status: ' + healthStatus + '\n' +
+        'worker: probationary-firefighter-display\n' +
+        healthDetail + '\n',
+        {
+          status: healthStatus === 'healthy' ? 200 : 503,
+          headers: {
+            'Content-Type':  'text/plain; charset=UTF-8',
+            'Cache-Control': 'no-store',
+          },
+        }
+      );
+    }
+
     const layoutParam = sanitizeParam(url.searchParams.get('layout')) || DEFAULT_LAYOUT;
     const layoutKey   = (layoutParam in LAYOUTS) ? layoutParam : DEFAULT_LAYOUT;
     const layout      = LAYOUTS[layoutKey];


### PR DESCRIPTION
## Summary

- Adds a `/healthz` route as the first check in the fetch handler (after URL parsing)
- Probes `https://oauth2.googleapis.com/token` with a POST; HTTP 400 = endpoint reachable = `healthy`
- Returns HTTP 200 with `status: healthy` or HTTP 503 with `status: degraded` plus detail
- Network failure or timeout (5 s) sets status to `degraded` with error message
- Display pages completely unchanged — only `src/index.js` modified (+40 lines)

## Test plan

- [ ] `GET /healthz` returns 200 with `status: healthy` and `worker: probationary-firefighter-display` when Google OAuth endpoint is reachable
- [ ] `GET /healthz` returns 503 with `status: degraded` when the probe fails or times out
- [ ] All existing display routes (`/`, `/?layout=…`) still render correctly
- [ ] `POST /healthz` still returns 405 (non-GET rejection fires before healthz check)

Closes #15

https://claude.ai/code/session_01LrpioFtGBLJkGXwTxd6Zex

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrpioFtGBLJkGXwTxd6Zex)_