### PR TITLE
fix: use no-store on cached response to prevent hardware browser caching rotation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,7 +291,9 @@ export default {
       });
 
       // Store a separately-headered copy in the Workers Cache API.
-      // The TTL is 3 days — long enough to cover an entire rotation block.
+      // Cache-Control is no-store so the hardware browser never caches
+      // the page locally. The Cloudflare Workers Cache API caches it
+      // server-side regardless of this header value.
       // The block index in the cache key naturally invalidates the entry when
       // the rotation advances so no explicit purge is ever required.
       // ?bg=dark requests are never cached.
@@ -300,7 +302,7 @@ export default {
           status: 200,
           headers: {
             'Content-Type':           'text/html; charset=utf-8',
-            'Cache-Control':          'public, max-age=' + (3 * 24 * 3600),
+            'Cache-Control':          'no-store',
             'X-Content-Type-Options': 'nosniff',
           },
         });


### PR DESCRIPTION
## Summary

- The response stored in Cloudflare's Cache API had `Cache-Control: public, max-age=259200` (3 days). On cache hits this header was forwarded to the hardware browser, which cached the page locally and never re-requested it — the meta-refresh never fired and the rotation froze.
- Changed `Cache-Control` on `responseToCache` from `public, max-age=259200` to `no-store`. The Cloudflare Workers Cache API stores and serves the response regardless of this header; it only affects downstream browser behavior.
- The cache miss path (`response`) already used `no-store` and was correct. Only the cached-response path was affected.

## Details

The response stored in Cloudflare's Cache API had Cache-Control:
public, max-age=259200 (3 days). On cache hits this header was sent
to the hardware browser, which cached the page locally for 3 days
and never re-requested it. The meta-refresh never fired and the
rotation never updated on hardware.

Fix: changed Cache-Control on responseToCache from public, max-age
to no-store. The Cloudflare Workers Cache API stores and serves the
response regardless of this header — it only affects downstream
browser behavior. The hardware browser now treats every response as
non-cacheable and re-requests the URL as directed by the display
system's reload cycle.

Reminder: close probationary-firefighter-display issue #43 once
verified on hardware at the next 7:30 AM rotation.

## Test plan

- [ ] Deploy to staging and confirm Cloudflare still caches responses server-side (cache hit on second request, low latency)
- [ ] Confirm response headers received by browser show `Cache-Control: no-store`
- [ ] Confirm no `public, max-age` in response headers
- [ ] Verify on hardware at next 7:30 AM rotation that the display updates correctly (closes issue #43)

https://claude.ai/code/session_01MufrJyyz7TSAb8uYQNR4fP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MufrJyyz7TSAb8uYQNR4fP)_