### PR TITLE
fix: accept HEAD requests for UptimeRobot health monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,13 @@ const MIN_REFRESH_SECONDS = 300;
 export default {
   async fetch(request, env) {
 
-    // Reject non-GET requests with a generic status to reduce attack surface.
-    if (request.method !== 'GET') {
-      return new Response('Method not allowed', { status: 405 });
+    // Allow GET and HEAD (HEAD is used by UptimeRobot health monitoring).
+    // All other methods are rejected to reduce attack surface.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', {
+        status: 405,
+        headers: { 'Allow': 'GET, HEAD' },
+      });
     }
 
     // Parse and validate the layout URL parameter before the try block so the
@@ -131,10 +135,12 @@ export default {
         healthDetail = 'google-apis: unreachable (' + (e && e.message ? e.message : String(e)) + ')';
       }
 
-      return new Response(
+      const healthBody =
         'status: ' + healthStatus + '\n' +
         'worker: probationary-firefighter-display\n' +
-        healthDetail + '\n',
+        healthDetail + '\n';
+      return new Response(
+        request.method === 'HEAD' ? null : healthBody,
         {
           status: healthStatus === 'healthy' ? 200 : 503,
           headers: {


### PR DESCRIPTION
## Summary

- Global method filter now allows both GET and HEAD (was GET-only)
- `/healthz` returns `null` body for HEAD requests (correct per HTTP spec)
- 405 response now includes `Allow: GET, HEAD` header

## Problem

UptimeRobot HTTP monitors send HEAD requests by default. The global method filter at the top of the fetch handler rejected all non-GET requests with a 405 before they could reach the `/healthz` route, causing UptimeRobot to report the worker as down.

## Changes

- `src/index.js` lines 100–106: Updated the global filter condition from `!== 'GET'` to `!== 'GET' && !== 'HEAD'`, and added `Allow: GET, HEAD` to the 405 response headers.
- `src/index.js` lines 134–147: Extracted the healthz body string into `healthBody`, then passes `null` when the request method is HEAD so no body is sent (correct HTTP spec behavior).
- No change to health check logic or any other routes.

## Test plan

- [ ] HEAD request to `/healthz` returns 200 with no body and correct `Content-Type` / `Cache-Control` headers
- [ ] GET request to `/healthz` returns 200 with plain-text body as before
- [ ] POST/PUT/DELETE to any route still returns 405 with `Allow: GET, HEAD` header
- [ ] GET to main display route still renders the firefighter page normally

https://claude.ai/code/session_01Ks5RyUXv44NDAgmX5yHTPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks5RyUXv44NDAgmX5yHTPF)_