### PR TITLE
fix: use flex: none on .photo-col to fix split/tri photo layout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ const SHEET_TAB_NAME = 'Firefighters';
 const ERROR_RETRY_SECONDS = 60;
 
 // Cache version — increment this value to bust any caches keyed on this Worker.
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 
 // Minimum meta-refresh interval in seconds. Prevents the refresh from becoming
 // unreasonably short if the Worker runs just before 7:30 AM.
@@ -731,9 +731,12 @@ function buildFirefighterPage(firefighter, photoFileId, layout, layoutKey, refre
     '  height: '         + availableHeight + 'px;' +
     '}' +
 
-    // Photo column — no internal padding; outer padding handles edge spacing
+    // Photo column — no internal padding; outer padding handles edge spacing.
+    // flex: none prevents flexbox from overriding the explicit width and height.
+    // Using flex: 0 0 photoWidth would set the wrong flex-basis axis in column
+    // layouts (split/tri), causing the photo to fill the full available height.
     '.photo-col {' +
-    '  flex: 0 0 ' + photoWidth  + 'px;' +
+    '  flex: none;' +
     '  width: '    + photoWidth  + 'px;' +
     '  height: '   + photoHeight + 'px;' +
     '  overflow: hidden;' +


### PR DESCRIPTION
## Summary

- Replaces `flex: 0 0 photoWidth` with `flex: none` on `.photo-col` to fix broken photo rendering in split and tri layouts
- Increments `CACHE_VERSION` from 2 → 3 to bust any caches keyed on this Worker

## Root cause

In split and tri layouts the `.content` flex container uses `flex-direction: column`, so `flex-basis` controls **height**, not width. The previous rule `flex: 0 0 photoWidth` was forcing the photo element to be `photoWidth` pixels **tall**, far exceeding the available height and pushing the info panel entirely off-screen. Wide and full layouts were unaffected because their container uses `flex-direction: row`.

## Fix

`flex: none` is equivalent to `flex: 0 0 auto`, which tells flexbox not to grow or shrink the element and to use its existing `width` and `height` properties instead. Those properties (`width: photoWidth`, `height: photoHeight`) were already set correctly on the same element, so the photo now renders at the right dimensions in all four layouts.

## Test plan

- [ ] Verify split layout: photo occupies ~38% of available height, info panel is fully visible below
- [ ] Verify tri layout: same stacked behavior as split
- [ ] Verify wide layout: photo still occupies ~42% of available width, info panel beside it (unaffected by this change)
- [ ] Verify full layout: same as wide (unaffected)

https://claude.ai/code/session_01N5NahUzADsu3SPRsgopQCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5NahUzADsu3SPRsgopQCS)_