### PR TITLE
fix: use object-fit contain for photo in split/tri layouts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ const SHEET_TAB_NAME = 'Firefighters';
 const ERROR_RETRY_SECONDS = 60;
 
 // Cache version — increment this value to bust any caches keyed on this Worker.
-const CACHE_VERSION = 3;
+const CACHE_VERSION = 4;
 
 // Minimum meta-refresh interval in seconds. Prevents the refresh from becoming
 // unreasonably short if the Worker runs just before 7:30 AM.
@@ -668,7 +668,7 @@ function buildFirefighterPage(firefighter, photoFileId, layout, layoutKey, refre
   const photoHtml = photoFileId
     ? '<img src="/photo/' + encodeURIComponent(photoFileId) + '" alt="Photo of ' +
         escapeHtml(firefighter.name) + '" ' +
-        'style="width:100%;height:100%;object-fit:cover;object-position:top center;" ' +
+        'style="width:100%;height:100%;display:block;" ' +
         'onerror="this.style.display=\'none\';this.nextElementSibling.style.display=\'block\';">' +
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" ' +
         'style="width:100%;height:100%;display:none;">' +
@@ -742,13 +742,16 @@ function buildFirefighterPage(firefighter, photoFileId, layout, layoutKey, refre
     '  overflow: hidden;' +
     '  background: #1a1a1a;' +
     '}' +
-    // Image fills the column; anchored to top so faces are not cropped
+    // wide/full: cover fills the tall narrow column and anchors to the top so
+    // faces are not cropped. split/tri: contain scales the portrait photo down
+    // to fit the short wide strip; the dark .photo-col background fills the bars.
     '.photo-col img {' +
     '  width: 100%;' +
     '  height: 100%;' +
-    '  object-fit: cover;' +
-    '  object-position: center top;' +
     '  display: block;' +
+    (isWideFamily
+      ? '  object-fit: cover; object-position: top center;'
+      : '  object-fit: contain;') +
     '}' +
 
     // Info panel — flex column so .qa-section can grow to fill remaining space


### PR DESCRIPTION
## Summary

- In split/tri layouts the photo column is a short, wide horizontal strip. `object-fit: cover` on a portrait photo scaled the image up until it filled the width, then cropped everything except a thin top slice — showing only the very top of the head.
- Consolidates `object-fit` and `object-position` from the `img` inline style into the `.photo-col img` CSS rule, conditioned on `isWideFamily`, eliminating the inline-style specificity conflict.
- Wide/full layouts keep `object-fit: cover; object-position: top center` (tall narrow column, face anchored). Split/tri layouts now use `object-fit: contain` so the portrait scales down to fit the short wide strip; the existing dark `#1a1a1a` background on `.photo-col` fills the letterbox bars.
- Bumps `CACHE_VERSION` to 4.

## Test plan

- [ ] Wide layout (`?layout=wide`): photo fills tall narrow column, face visible at top — no regression
- [ ] Full layout (`?layout=full`): same as wide — no regression
- [ ] Split layout (`?layout=split`): portrait photo fits entirely within the short wide strip with dark bars on each side — no top-of-head crop
- [ ] Tri layout (`?layout=tri`): same as split — no top-of-head crop
- [ ] Firefighter with no photo: silhouette SVG displays correctly in all four layouts

https://claude.ai/code/session_01VmayefpuefpZhZY2EprGun

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmayefpuefpZhZY2EprGun)_